### PR TITLE
Fix loading order - constant moved to module root

### DIFF
--- a/app/controllers/concerns/the_comments/controller.rb
+++ b/app/controllers/concerns/the_comments/controller.rb
@@ -1,6 +1,4 @@
 module TheComments
-  COMMENTS_COOKIES_TOKEN = 'JustTheCommentsCookies'
-
   # Base functionality of Comments Controller
   # class CommentsController < ApplicationController
   #   include TheComments::Controller

--- a/lib/the_comments.rb
+++ b/lib/the_comments.rb
@@ -8,6 +8,8 @@ require 'the_comments/config'
 require 'the_comments/version'
 
 module TheComments
+  COMMENTS_COOKIES_TOKEN = 'JustTheCommentsCookies'
+
   class Engine < Rails::Engine
     config.autoload_paths += Dir["#{config.root}/app/controllers/concerns/**/"]
     config.autoload_paths += Dir["#{config.root}/app/models/concerns/**/"]


### PR DESCRIPTION
Fixes: uninitialized constant TheComments::COMMENTS_COOKIES_TOKEN
