### PR TITLE
Replace `state_machine` gem with `state_machines-activerecord` one

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please try playing around with the **[Dummy App](spec/dummy_app)** in the `spec`
 
 **NB: In the following examples, `Posts` is the model to which comments are being added. For your app, the model might be `Articles` or similar instead.**
 
-### 1. Install Gems 
+### 1. Install Gems
 
 **Gemfile**
 
@@ -99,7 +99,7 @@ Will create:
 * config/initializers/the_comments.rb
 * app/controllers/comments_controller.rb
 * app/models/comment.rb
- 
+
 :warning: &nbsp; **Open each file and follow the instructions**
 
 ### 4. Models modifictions
@@ -112,7 +112,7 @@ class User < ActiveRecord::Base
 
   has_many :posts
 
-  # IT'S JUST AN EXAMPLE OF ANY ROLE SYSTEM 
+  # IT'S JUST AN EXAMPLE OF ANY ROLE SYSTEM
   def admin?
     self == User.first
   end
@@ -248,33 +248,6 @@ Add the following to your Comments Controller.
     end
 
 See [here](https://github.com/the-teacher/the_comments/issues/34).
-
-<hr>
-
-For errors with `around_validation`.
-
-Example:
-
-    NoMethodError - protected method `around_validation' called for #<StateMachine::Machine:0x007f84148c3c60>:
-
-Create a new file `config/state_machine.rb`.
-
-    # Rails 4.1.0.rc1 and StateMachine don't play nice
-    # https://github.com/pluginaweek/state_machine/issues/295
-
-    require 'state_machine/version'
-
-    unless StateMachine::VERSION == '1.2.0'
-      # If you see this message, please test removing this file
-      # If it's still required, please bump up the version above
-      Rails.logger.warn "Please remove me, StateMachine version has changed"
-    end
-
-    module StateMachine::Integrations::ActiveModel
-      public :around_validation
-    end
-
-See [here](https://github.com/pluginaweek/state_machine/issues/295).
 
 <hr>
 

--- a/docs/advanced_installation.md
+++ b/docs/advanced_installation.md
@@ -70,7 +70,7 @@ Will create:
 * config/initializers/the_comments.rb
 * app/controllers/comments_controller.rb
 * app/models/comment.rb
- 
+
 :warning: &nbsp; **Open each file and follow an instructions**
 
 ### 4. Models modifictions
@@ -120,7 +120,7 @@ class Post < ActiveRecord::Base
     ['', self.class.to_s.tableize, id].join('/')
   end
 
-  # gem 'state_machine'
+  # gem 'state_machines-activerecord'
   # Migration: t.string :state
   # => "published" | "draft" | "deleted"
   def commentable_state

--- a/docs/whats_wrong_with_other_gems.md
+++ b/docs/whats_wrong_with_other_gems.md
@@ -4,7 +4,7 @@
 
 Take a look at [Ruby-Toolbox](https://www.ruby-toolbox.com/categories/rails_comments). What can we see?
 
-* [Acts as commentable with threading](https://github.com/elight/acts_as_commentable_with_threading) - Where is the render helper for the tree? There is no helper! Am I supposed to write a render helper for the tree myself? Nooooo!!! I'm sorry, I can't use this gem. 
+* [Acts as commentable with threading](https://github.com/elight/acts_as_commentable_with_threading) - Where is the render helper for the tree? There is no helper! Am I supposed to write a render helper for the tree myself? Nooooo!!! I'm sorry, I can't use this gem.
 * [acts_as_commentable](https://github.com/jackdempsey/acts_as_commentable) - I can see the code for models. But I can't see the code for controllers and views. Unfortunately, there is no threading. This isn't enough for me.
 * [opinio](https://github.com/Draiken/opinio) - Better, but still no threading. I can do better!
 * [has_threaded_comments](https://github.com/aarongough/has_threaded_comments) - A solid gem. Has model, controller and view helpers for tree rendering! **But** last activity was 2 years ago, it still needs a few features - I can do better.
@@ -20,9 +20,9 @@ Take a look at [Ruby-Toolbox](https://www.ruby-toolbox.com/categories/rails_comm
 7. TheComments is an "all-in-one" solution.<br>
    It has: Models and Controllers logic (via concerns), Generators, Views, Helper for fast Tree rendering and Admin UI.
 8. If you have problems with TheComments, I'll try to help you via skype: **ilya.killich**
-   
+
 ### TheComments based on:
 
 1. [AwesomeNestedSet](https://github.com/collectiveidea/awesome_nested_set) - for comments threading
 2. [TheSortableTree](https://github.com/the-teacher/the_sortable_tree) - for fast rendering of comments tree
-3. [State Machine](https://github.com/pluginaweek/state_machine) - to provide easy and correct recalculation cache counters on states transitions
+3. [State Machines](https://github.com/state-machines/state_machines) - to provide easy and correct recalculation cache counters on states transitions

--- a/lib/the_comments.rb
+++ b/lib/the_comments.rb
@@ -1,5 +1,4 @@
-require 'state_machine'
-require 'state_machine/version'
+require 'state_machines-activerecord'
 
 require 'the_simple_sort'
 require 'the_sortable_tree'
@@ -19,20 +18,3 @@ end
 # Loading of concerns
 _root_ = File.expand_path('../../',  __FILE__)
 require "#{_root_}/config/routes.rb"
-
-if StateMachine::VERSION.to_f <= 1.2
-  puts '~' * 50
-  puts 'TheComments'
-  puts '~' * 50
-  puts 'WARNING!'
-  puts 'StateMachine patch for Rails4 will be applied'
-  puts
-  puts '> private method *around_validation* from StateMachine::Integrations::ActiveModel will be public'
-  puts
-  puts 'https://github.com/pluginaweek/state_machine/issues/295'
-  puts 'https://github.com/pluginaweek/state_machine/issues/251'
-  puts '~' * 50
-  module StateMachine::Integrations::ActiveModel
-    public :around_validation
-  end
-end

--- a/the_comments.gemspec
+++ b/the_comments.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'state_machine',     '~> 1.2.0'
+  gem.add_dependency 'state_machines-activerecord', '~> 0.3.0'
   gem.add_dependency 'the_sortable_tree', '~> 2.5.0'
   gem.add_dependency 'the_simple_sort',   '~> 0.0.2'
 


### PR DESCRIPTION
Hi Ilya. As you know `state_machine` gem is not maintained anymore. But there is a good replacement for it https://github.com/state-machines/state_machines. New maintainers have updated code to get rid of much legacy. They have separated parts of gem to several gems like `state_machines-activerecord`, `state_machines-mongomapper` and so on. Also they make it work on Rails 4 without hacks on `around_validation`.

This PR introduces the replacement of `state_machine` gem to `state_machines-activerecord` as `the_comments` gem is based on activerecord.